### PR TITLE
git submodule repos moved from ggeorgakoudis to Python-for-HPC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/ggeorgakoudis/llvm-project.git
 [submodule "llvmliteWithOpenmp"]
 	path = llvmliteWithOpenmp
-	url = https://github.com/ggeorgakoudis/llvmliteWithOpenmp.git
+	url = https://github.com/Python-for-HPC/llvmliteWithOpenmp.git
 [submodule "NumbaWithOpenmp"]
 	path = NumbaWithOpenmp
-	url = https://github.com/ggeorgakoudis/NumbaWithOpenmp.git
+	url = https://github.com/Python-for-HPC/NumbaWithOpenmp.git


### PR DESCRIPTION
The llvmliteWithOpenmp and NumbaWithOpenmp git submodule repos appear to have moved. Changed from ggeorgakoudis account to Python-for-HPC. Updated .gitmodules accordingly.