### PR TITLE
Release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ PyOMP is distributed as a package through Conda, currently supporting linux-64
 (x86_64), osx-arm64 (mac), linux-arm64, and linux-ppc64le architectures.
 
 ```bash
-conda install -c python-for-hpc -c conda-forge --override-channels pyomp
+conda install -c python-for-hpc -c conda-forge pyomp
 ```
 
 ## Trying it out
@@ -56,7 +56,7 @@ docker run -it ghcr.io/python-for-hpc/pyomp:latest /bin/bash
 
 To use Jupyter, run without arguments and forward port 8888.
 ```
-podman run -it -p 8888:8888 ghcr.io/python-for-hpc/pyomp:latest
+docker run -it -p 8888:8888 ghcr.io/python-for-hpc/pyomp:latest
 ```
 Jupyter will start as a service on localhost with token authentication by default.
 Grep the url with the token from the output and copy it to the browser.

--- a/buildscripts/conda-recipes/llvm-openmp-dev/meta.yaml
+++ b/buildscripts/conda-recipes/llvm-openmp-dev/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   url: https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/openmp-14.0.6.src.tar.xz
   sha256: 4f731ff202add030d9d68d4c6daabd91d3aeed9812e6a5b4968815cfdff0eb1f
+  patches:
+    - patches/0001-BACKPORT-Fix-for-CUDA-OpenMP-RTL.patch
 
 build:
   merge_build_host: False

--- a/buildscripts/conda-recipes/llvm-openmp-dev/patches/0001-BACKPORT-Fix-for-CUDA-OpenMP-RTL.patch
+++ b/buildscripts/conda-recipes/llvm-openmp-dev/patches/0001-BACKPORT-Fix-for-CUDA-OpenMP-RTL.patch
@@ -1,0 +1,50 @@
+From 4e2d04de758d0ae37a1fd663c3c139293bfb3dc4 Mon Sep 17 00:00:00 2001
+From: Giorgis Georgakoudis <georgakoudis1@llnl.gov>
+Date: Tue, 28 Nov 2023 01:16:15 -0800
+Subject: [PATCH] [BACKPORT] Fix for CUDA OpenMP RTL
+# Based on LLVM commit 545fcc3d842c0912db61591520bd4f760686c5a3
+
+---
+ openmp-14.0.6.src/libomptarget/plugins/cuda/src/rtl.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/openmp-14.0.6.src/libomptarget/plugins/cuda/src/rtl.cpp b/openmp-14.0.6.src/libomptarget/plugins/cuda/src/rtl.cpp
+index 0ca05f0ec3a0..16da3f434bba 100644
+--- a/openmp-14.0.6.src/libomptarget/plugins/cuda/src/rtl.cpp
++++ b/openmp-14.0.6.src/libomptarget/plugins/cuda/src/rtl.cpp
+@@ -234,6 +234,7 @@ template <typename T> class ResourcePoolTy {
+   std::mutex Mutex;
+   /// Pool of resources.
+   std::vector<T> Resources;
++  std::vector<T> Pool;
+   /// A reference to the corresponding allocator.
+   AllocatorTy<T> Allocator;
+
+@@ -243,11 +244,13 @@ template <typename T> class ResourcePoolTy {
+     auto CurSize = Resources.size();
+     assert(Size > CurSize && "Unexpected smaller size");
+     Resources.reserve(Size);
++    Pool.reserve(Size);
+     for (auto I = CurSize; I < Size; ++I) {
+       T NewItem;
+       int Ret = Allocator.create(NewItem);
+       if (Ret != OFFLOAD_SUCCESS)
+         return false;
++      Pool.push_back(NewItem);
+       Resources.push_back(NewItem);
+     }
+     return true;
+@@ -308,8 +311,9 @@ public:
+   /// Released all stored resources and clear the pool.
+   /// Note: This function is not thread safe. Be sure to guard it if necessary.
+   void clear() noexcept {
+-    for (auto &R : Resources)
++    for (auto &R : Pool)
+       (void)Allocator.destroy(R);
++    Pool.clear();
+     Resources.clear();
+   }
+ };
+-- 
+2.29.1
+

--- a/buildscripts/conda-recipes/numba/meta.yaml
+++ b/buildscripts/conda-recipes/numba/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/Python-for-HPC/numbaWithOpenmp.git
-  git_rev: e86d15701de24f66b1da3fd9015208d25ea26d81
+  git_rev: 296fb858b0a6800323e9b46b027c32636ecc80c7
   git_depth: 1
 
 build:

--- a/buildscripts/conda-recipes/pyomp/meta.yaml
+++ b/buildscripts/conda-recipes/pyomp/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pyomp
-  version: 0.1.1
+  version: 0.1.2
 
 build:
   string: {{ (GITHUB_HEAD_SHA | default(''))[:7] ~ (CI_COMMIT_SHA | default(''))[:7] }}


### PR DESCRIPTION
- Update numbawithopenmp to 296fb858b0a6800323e9b46b027c32636ecc80c7
  - Support slicing for target mappings
  - Support code caching for CPU, GPU regions
- Fix OpenMP CUDA RTL bug #10
- Fix README

Closes #10 
    