### PR TITLE
Fix compat issues with LLVM15 in numba 0.61.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,14 +121,9 @@ class BuildCMakeExt(build_ext):
 
     def _env_toolchain_args(self, ext):
         args = []
-        # Forward LLVM_DIR and CLANG_TOOL if provided.
+        # Forward LLVM_DIR if provided.
         if os.environ.get("LLVM_DIR"):
             args.append(f"-DLLVM_DIR={os.environ['LLVM_DIR']}")
-        if ext.name == "libomp":
-            # CLANG_TOOL is used by libomp to find clang for generating the OpenMP
-            # device runtime bitcodes.
-            if os.environ.get("CLANG_TOOL"):
-                args.append(f"-DCLANG_TOOL={os.environ['CLANG_TOOL']}")
         return args
 
 

--- a/src/numba/openmp/libs/libomp/patches/15.0.7/0003-Disable-opaque-pointers-DeviceRTL-bitcode.patch
+++ b/src/numba/openmp/libs/libomp/patches/15.0.7/0003-Disable-opaque-pointers-DeviceRTL-bitcode.patch
@@ -1,0 +1,12 @@
+diff --git a/libomptarget/DeviceRTL/CMakeLists.txt b/libomptarget/DeviceRTL/CMakeLists.txt
+index ce66214..04c9dd5 100644
+--- a/libomptarget/DeviceRTL/CMakeLists.txt
++++ b/libomptarget/DeviceRTL/CMakeLists.txt
+@@ -127,6 +127,7 @@ set(bc_flags -c -emit-llvm -std=c++17 -fvisibility=hidden
+              -fopenmp -fopenmp-cuda-mode
+              -I${include_directory}
+              -I${devicertl_base_directory}/../include
++             -Xclang -no-opaque-pointers
+              ${LIBOMPTARGET_LLVM_INCLUDE_DIRS_DEVICERTL}
+ )
+ 

--- a/src/numba/openmp/libs/pass/CMakeLists.txt
+++ b/src/numba/openmp/libs/pass/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(LLVM REQUIRED CONFIG NO_DEFAULT_PATH PATHS
   ${LLVM_DIR}
 )
 
-message(STATUS "LLVM_VERSION ${LLVM_VERSION}")
+message(STATUS "Found LLVM version ${LLVM_VERSION}")
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 


### PR DESCRIPTION
- Add patch for openmp 15.0.7 to build DeviceRTL bitcodes without opaque pointers
- Cleanup code and improve diagnostic output