### PR TITLE
Refactor OpenMP grammar for LALR parsing

### DIFF
--- a/src/numba/openmp/omp_grammar.py
+++ b/src/numba/openmp/omp_grammar.py
@@ -54,12 +54,41 @@ openmp_grammar = r"""
                     | ordered_construct
     for_simd_construct: for_simd_directive
     for_simd_directive: FOR SIMD [for_simd_clause*]
-    for_simd_clause: for_clause
-                   | simd_clause
+    // LALR: avoid ambiguity from overlapping expansions in for_clause vs simd_clause
+    for_simd_clause: ORDERED
+                   | schedule_clause
+                   | collapse_clause
+                   | private_clause
+                   | copyprivate_clause
+                   | firstprivate_clause
+                   | lastprivate_clause
+                   | data_sharing_clause
+                   | data_default_clause
+                   | copyin_clause
+                   | reduction_clause
+                   | NOWAIT
+                   | aligned_clause
+                   | linear_clause
+                   | uniform_clause
+                   | inbranch_clause
     parallel_for_simd_construct: parallel_for_simd_directive
     parallel_for_simd_directive: PARALLEL FOR SIMD [parallel_for_simd_clause*]
-    parallel_for_simd_clause: parallel_for_clause
-                            | simd_clause
+    // LALR: avoid ambiguity from overlapping expansions in parallel_for_clause vs simd_clause
+    parallel_for_simd_clause: if_clause
+                            | num_threads_clause
+                            | ORDERED
+                            | schedule_clause
+                            | collapse_clause
+                            | data_default_clause
+                            | private_clause
+                            | firstprivate_clause
+                            | lastprivate_clause
+                            | data_sharing_clause
+                            | reduction_clause
+                            | aligned_clause
+                            | linear_clause
+                            | uniform_clause
+                            | inbranch_clause
     distribute_construct: distribute_directive
     distribute_simd_construct: distribute_simd_directive
     distribute_directive: DISTRIBUTE [distribute_clause*]
@@ -509,10 +538,9 @@ openmp_grammar = r"""
                         | device_clause
                         | if_clause
     motion_clause: update_motion_type "(" variable_array_section_list ")"
-    variable_array_section_list: PYTHON_NAME
+    // LALR: name_slice already covers bare PYTHON_NAME, so avoid the ambiguous PYTHON_NAME alternatives.
+    variable_array_section_list: name_slice
                            //    | array_section
-                               | name_slice
-                               | variable_array_section_list "," PYTHON_NAME
                                | variable_array_section_list "," name_slice
                            //    | variable_array_section_list "," array_section
     //array_section: PYTHON_NAME array_section_subscript
@@ -690,7 +718,3 @@ openmp_grammar = r"""
     %import common.WS
     %ignore WS
     """
-
-"""
-    name_slice: PYTHON_NAME [ "[" slice ["," slice]* "]" ]
-"""

--- a/src/numba/openmp/omp_lower.py
+++ b/src/numba/openmp/omp_lower.py
@@ -2867,6 +2867,15 @@ class OpenmpVisitor(Transformer):
         else:
             return NameSlice(args[0], args[1:])
 
+    def variable_array_section_list(self, args):
+        if DEBUG_OPENMP >= 1:
+            print("visit variable_array_section_list", args, type(args))
+        if len(args) == 1:
+            return args
+        else:
+            args[0].append(args[1])
+            return args[0]
+
     def var_list(self, args):
         if DEBUG_OPENMP >= 1:
             print("visit var_list", args, type(args))

--- a/src/numba/openmp/parser.py
+++ b/src/numba/openmp/parser.py
@@ -2,5 +2,9 @@ from lark import Lark
 
 from .omp_grammar import openmp_grammar
 
-openmp_parser = Lark(openmp_grammar, start="openmp_statement")
-var_collector_parser = Lark(openmp_grammar, start="openmp_statement")
+# Use Lark's contextual lexer with LALR to resolve keyword-vs-identifier
+# overlaps (e.g. `TO` vs `PYTHON_NAME`) without reserving words.
+_LARK_KWARGS = dict(parser="lalr", lexer="contextual")
+
+openmp_parser = Lark(openmp_grammar, start="openmp_statement", **_LARK_KWARGS)
+var_collector_parser = Lark(openmp_grammar, start="openmp_statement", **_LARK_KWARGS)

--- a/src/numba/openmp/tests/test_openmp.py
+++ b/src/numba/openmp/tests/test_openmp.py
@@ -1926,7 +1926,14 @@ class TestOpenmpConstraints(TestOpenmpBase):
 
         with self.assertRaises(Exception) as raises:
             test_impl(12)
-        self.assertIn("No terminal matches", str(raises.exception))
+        # Lark error text differs across versions: lexer failure ("No terminal matches")
+        # vs parser failure ("Unexpected token") for unsupported clauses like NOWAIT here.
+        err = str(raises.exception)
+        self.assertIn("nowait", err.lower())
+        self.assertTrue(
+            "No terminal matches" in err or "Unexpected token" in err,
+            err,
+        )
 
     def test_parallel_double_num_threads(self):
         @njit


### PR DESCRIPTION
Although, we expect our overhead from parsing few OpenMP constructs to be minimal, I think it's good idea to ensure it by using LALR parsing.

This PR slightly refactors our OpenMP grammar to enable LALR parsing.