### PR TITLE
Adding new committee behavior of shared.

### DIFF
--- a/src/numba/openmp/config.py
+++ b/src/numba/openmp/config.py
@@ -25,3 +25,4 @@ DEBUG_OPENMP_LLVM_PASS = _safe_readenv("NUMBA_DEBUG_OPENMP_LLVM_PASS", int, 0)
 OPENMP_DISABLED = _safe_readenv("NUMBA_OPENMP_DISABLED", int, 0)
 # Use toolchain for device code compilation by default to avoid issues with libomptarget compatibility checks.
 OPENMP_DEVICE_TOOLCHAIN = _safe_readenv("NUMBA_OPENMP_DEVICE_TOOLCHAIN", int, 1)
+SMART_PRIVATIZE = _safe_readenv("NUMBA_SMART_PRIVATIZE", int, 1)

--- a/src/numba/openmp/omp_lower.py
+++ b/src/numba/openmp/omp_lower.py
@@ -18,7 +18,7 @@ import operator
 import sys
 import os
 
-from .config import DEBUG_OPENMP
+from .config import DEBUG_OPENMP, SMART_PRIVATIZE
 from .parser import openmp_parser
 from .analysis import (
     remove_ssa,
@@ -304,7 +304,10 @@ class OpenmpVisitor(Transformer):
 
         # All private variables (user-defined and compiler-generated)
         for var_name in sorted(private_to_region):
-            add_clause(var_name, "QUAL.OMP.PRIVATE")
+            if SMART_PRIVATIZE:
+                add_clause(var_name, "QUAL.OMP.PRIVATE")
+            else:
+                add_clause(var_name, "QUAL.OMP.SHARED")
 
     def make_implicit_explicit_target(
         self,


### PR DESCRIPTION
Add NUMBA_SMART_PRIVATIZE default to true to give old behavior of only used in region to be private.  If set to false then such variables become shared.